### PR TITLE
Add option for active-low relays

### DIFF
--- a/bin/rpi-switch-mqtt
+++ b/bin/rpi-switch-mqtt
@@ -14,5 +14,6 @@ def main(argv):
             server = Switcher(config)
             server.start()
 
+
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/rpi_switch_mqtt/switcher.py
+++ b/rpi_switch_mqtt/switcher.py
@@ -12,17 +12,24 @@ class Switch:
     gpio = None
     topic_status = None
 
-    def __init__(self, gpio, topic_status):
+    def __init__(self, gpio, topic_status, is_active_low=False):
         self.gpio = gpio
         self.topic_status = topic_status
+        self.is_active_low = is_active_low
         GPIO.setup(self.gpio, GPIO.OUT)
         self.off()
 
     def on(self):
-        GPIO.output(self.gpio, GPIO.HIGH)
+        if self.is_active_low:
+            GPIO.output(self.gpio, GPIO.LOW)
+        else:
+            GPIO.output(self.gpio, GPIO.HIGH)
 
     def off(self):
-        GPIO.output(self.gpio, GPIO.LOW)
+        if self.is_active_low:
+            GPIO.output(self.gpio, GPIO.HIGH)
+        else:
+            GPIO.output(self.gpio, GPIO.LOW)
 
 
 class Switcher:
@@ -34,7 +41,7 @@ class Switcher:
     def __init__(self, config):
         self.config = config
         for switch_cfg in self.config['switches']:
-            self.switches[switch_cfg['topic_set']] = Switch(int(switch_cfg['gpio']), switch_cfg['topic_status'])
+            self.switches[switch_cfg['topic_set']] = Switch(int(switch_cfg['gpio']), switch_cfg['topic_status'], switch_cfg.get('active_low', False))
 
     def verbose(self, message):
         if self.config and 'verbose' in self.config and self.config['verbose'] == 'true':

--- a/rpi_switch_mqtt/switcher.py
+++ b/rpi_switch_mqtt/switcher.py
@@ -62,6 +62,7 @@ class Switcher:
                     self.mqtt_client.subscribe(switch_cfg['topic_set'], 0)
                 self.mqtt_client.loop_forever()
             except:
+                GPIO.cleanup()
                 self.error(traceback.format_exc())
                 self.mqtt_client = None
         else:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('LICENSE') as f:
 
 setup(
     name='rpi-switch-mqtt',
-    version='0.0.1',
+    version='0.0.4',
     description='Use mqtt to control relays connected to raspberry',
     long_description=readme,
     author='David Uebelacker',


### PR DESCRIPTION
Some relay modules are active-low, so I added this support to the config file on a per-switch basis as completely optional and defaults to the previous behavior of HIGH = On. 
I also increased the version to be a step above the current pip module.
Let me know if I missed anything. I am currently running with these changes on a RPi 2B without any issues and works great with my active-low relay module.
Thanks!